### PR TITLE
Use the default integration branch for greenkeeper updates

### DIFF
--- a/setup-downstream-integration.sh
+++ b/setup-downstream-integration.sh
@@ -87,13 +87,14 @@ function setup_commands () {
     DOWNSTREAM_REPO_URL="git@github.com:$DOWNSTREAM_REPO_NAME.git"
     mkdir -p $CURRENT_DOWNSTREAM_PATH
 
-    if [ $CURRENT_UPSTREAM_BRANCH == "master" ]; then
-      >&2 echo "The CURRENT_UPSTREAM_BRANCH is 'master'";
+    if [ $CURRENT_UPSTREAM_BRANCH == "master" ] || [ $CURRENT_UPSTREAM_BRANCH =~ ^greenkeeper/ ]; then
+      >&2 echo "The CURRENT_UPSTREAM_BRANCH is '$CURRENT_UPSTREAM_BRANCH'";
+      if [ $CURRENT_UPSTREAM_BRANCH =~ ^greenkeeper/ ]; then >&2 echo "Use the default downstream integration branch because of Greenkeeper"; fi
       git clone --branch $DEFAULT_INTEGRATION_BRANCH --depth 50 $DOWNSTREAM_REPO_URL $CURRENT_DOWNSTREAM_PATH || \
       git clone --branch master --depth 50 $DOWNSTREAM_REPO_URL $CURRENT_DOWNSTREAM_PATH || \
       return 1
     else
-      >&2 echo "The CURRENT_UPSTREAM_BRANCH is not 'master'" && \
+      >&2 echo "The CURRENT_UPSTREAM_BRANCH is not 'master'";
       git clone --branch $CURRENT_UPSTREAM_BRANCH --depth 50 $DOWNSTREAM_REPO_URL $CURRENT_DOWNSTREAM_PATH || \
       git clone --branch $CUSTOM_INTEGRATION_BRANCH_NAME --depth 50 $DOWNSTREAM_REPO_URL $CURRENT_DOWNSTREAM_PATH || \
       git clone --branch $DEFAULT_INTEGRATION_BRANCH --depth 50 $DOWNSTREAM_REPO_URL $CURRENT_DOWNSTREAM_PATH || \


### PR DESCRIPTION
Without this fix, the tests always run against the master branch and make the greenkeeper PRs fail.